### PR TITLE
Switch from Spring Initializer to DynamicPropertySource

### DIFF
--- a/src/test/java/com/example/demo/DatabaseTest.java
+++ b/src/test/java/com/example/demo/DatabaseTest.java
@@ -2,16 +2,12 @@ package com.example.demo;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.util.TestPropertyValues;
-import org.springframework.context.ApplicationContextInitializer;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
-
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -22,23 +18,19 @@ import java.util.List;
 @Testcontainers
 @SpringBootTest
 @TestPropertySource(locations = "classpath:application.properties")
-@ContextConfiguration(initializers = {DatabaseTest.Initializer.class})
 @Sql(scripts = {"/data.sql"})
 public class DatabaseTest {
 
     @Container
-    public static final MySQLContainer databaseContainer = new MySQLContainer<>("mysql:5.7")
+    static final MySQLContainer<?> databaseContainer = new MySQLContainer<>("mysql:5.7")
         .withUsername("fungus")
         .withPassword("brungus");
 
-    static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
-        public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
-            TestPropertyValues.of(
-                "spring.datasource.url=" + databaseContainer.getJdbcUrl(),
-                "spring.datasource.username=" + databaseContainer.getUsername(),
-                "spring.datasource.password=" + databaseContainer.getPassword()
-            ).applyTo(configurableApplicationContext.getEnvironment());
-        }
+    @DynamicPropertySource
+    static void mySQLProperties(DynamicPropertyRegistry registry) {
+            registry.add("spring.datasource.url", databaseContainer::getJdbcUrl);
+            registry.add("spring.datasource.username", databaseContainer::getUsername);
+            registry.add("spring.datasource.password", databaseContainer::getPassword);
     }
 
     @Autowired


### PR DESCRIPTION
- Passing the testcontainer db connection info from the container
to Spring was messy (nested class, code didn't explain itself well)
- Switched from using an initializer class to using `@DynamicPropertySource`
- Makes code intent a bit clearer, lowers test complexity a bit.